### PR TITLE
Making less specific to GCS notifications…

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ovotech/clj-gcp "0.2.0"
+(defproject ovotech/clj-gcp "0.3.0"
   :description "Clojure utilities for the Google Cloud Platform"
 
   :url "https://github.com/ovotech/clj-gcp"


### PR DESCRIPTION
…but still supporting the original message format passed to handlers.

There now two kinds of subscriptions:
 - `:clj-gcp.pub-sub.core/subscriber`
   - produces a message which is a map with the keys `:pubsub/ack-id`, `:pubsub/attributes` and the new `:pubsub/payload` which is the UTF-8 value of the notification.
 - `:clj-gcp.pub-sub.core/notification-subscriber`
   - produces a message in the "notification" format previous used by `:clj-gcp.pub-sub.core/subscriber` which involved json decoding the message payload and merging the attributes and ack-id into the result in map

Existing users of the library should be able to just change to use `:clj-gcp.pub-sub.core/notification-subscriber`.

**N.B. this has not been extensively integration tested**