### PR TITLE
Make defrecords public so they can be extended

### DIFF
--- a/src/clj_gcp/storage/core.clj
+++ b/src/clj_gcp/storage/core.clj
@@ -85,7 +85,6 @@
     (gcs-get-blob gservice bucket-name blob-name))
   (blob-writer [this bucket-name blob-name opts]
     (gcs-blob-writer gservice bucket-name blob-name opts)))
-(alter-meta! #'->GCSStorageClient assoc :private true)
 
 (defn gcs-healthcheck
   []
@@ -183,7 +182,6 @@
   (exists? [_ bucket blob-name] (fs-exists base-path bucket blob-name))
   (blob-writer [_ bucket blob-name opts]
     (fs-blob-writer base-path bucket blob-name opts)))
-(alter-meta! #'->FileSystemStorageClient assoc :private true)
 
 (defn ->file-system-storage-client
   [base-path]


### PR DESCRIPTION
Hi,

We are using this library (thanks!) and want to add a new function to the implementations of `StorageClient`, namely `bucket-exists?`. To do this now we have to create our own `StorageClient` protocol with the extra method, and then create two `deftype`s that wrap the implementations of `FileSystemStorageClient` and `GCSStorageClient`, and just dispatch to the functions of the client in this library. If would be much nicer if we could do this:

```
(defprotocol IBucketExists
  (bucket-exists? [this bucket-name]))

(extend-type GCSStorageClient
  IBucketExists
  (bucket-exists? [this bucket-name] ...))
```

Because the `defrecord` is private this is not possible. 

This PR makes them public. Let me if you have any questions or concerns.

Kind regards,
Erwin