### PR TITLE
deps: replace deprecated raynes/fs with clj-commons/fs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ovotech/clj-gcp "0.6.4"
+(defproject ovotech/clj-gcp "0.6.5"
   :description "Clojure utilities for the Google Cloud Platform"
 
   :url "https://github.com/ovotech/clj-gcp"
@@ -8,6 +8,7 @@
   :dependencies [;;;
 
                  [cheshire "5.10.0"]
+                 [clj-commons/fs "1.5.2"]
                  [com.google.cloud/google-cloud-pubsub "1.108.1"]
                  [com.google.oauth-client/google-oauth-client "1.31.0"]
                  [com.google.cloud/google-cloud-storage "1.111.2"
@@ -15,7 +16,6 @@
                  [digest "1.4.9"]
                  [iapetos "0.1.8"]
                  [integrant "0.8.0"]
-                 [me.raynes/fs "1.4.6"]
                  [medley "1.3.0"]
                  [metosin/ring-http-response "0.9.1"]
                  [org.clojure/clojure "1.10.1"]


### PR DESCRIPTION
this fixes a Zip-Slip vulnerability: https://app.snyk.io/vuln/SNYK-JAVA-MERAYNES-32379

up-to-date fork: https://github.com/clj-commons/fs