### PR TITLE
Add cause to ex-info when blob missing

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ovotech/clj-gcp "0.6.11"
+(defproject ovotech/clj-gcp "0.6.12"
   :description "Clojure utilities for the Google Cloud Platform"
 
   :url "https://github.com/ovotech/clj-gcp"

--- a/src/clj_gcp/storage/core.clj
+++ b/src/clj_gcp/storage/core.clj
@@ -62,7 +62,9 @@
                          :metadata (into {} (.getMetadata blob)))
            (s/assert ::blob)))
     (throw (ex-info "no such blob"
-                    {:blob-name blob-name, :bucket-name bucket-name}))))
+                    {:cause :no-such-blob
+                     :blob-name blob-name,
+                     :bucket-name bucket-name}))))
 
 (defn- gcs-blob-writer
   ([gservice bucket-name blob-name]


### PR DESCRIPTION
Currently when the exception for a blob being missing is thrown it's a little ambiguous what the real exception is.
This change adds an explicit `:cause` to the map exception that we can integrate later